### PR TITLE
Allow EFI boot used by Fedora IoT edition.

### DIFF
--- a/config-bcm27xx.cfg
+++ b/config-bcm27xx.cfg
@@ -92,6 +92,10 @@ CONFIG_LWTUNNEL_BPF=y
 CONFIG_EFI_VARS=y
 CONFIG_EFI_BOOTLOADER_CONTROL=n
 
+# Required to boot Fedora IoT edition
+CONFIG_EFI_ARMSTUB_DTB_LOADER=y
+CONFIG_EFI=y
+
 # Don't want dwc2 built-in for bcmrpi3_defconfig (aarch64)
 CONFIG_USB_DWC2=m
 CONFIG_USB_DWC2_HOST=n

--- a/kernel.spec
+++ b/kernel.spec
@@ -68,7 +68,7 @@
 # For non-released -rc kernels, this will be appended after the rcX and
 # gitX tags, so a 3 here would become part of release "0.rcX.gitX.3"
 #
-%global baserelease 1
+%global baserelease 2
 
 # RaspberryPi foundation git snapshot (short)
 %global rpi_gitshort 900790847
@@ -1650,6 +1650,9 @@ fi
 
 
 %changelog
+* Wed Feb 03 2021 Peter Oliver <rpm@mavit.org.uk> - 5.10.10-2.rpi
+- Allow EFI boot used by Fedora IoT edition.
+
 * Mon Jan 25 2021 Damian Wrobel <dwrobel@ertelnet.rybnik.pl> - 5.10.10-1.rpi
 - Update to stable kernel patch v5.10.10
 - Sync RPi patch to git revision: 900790847a10954e7dcaeb4fe86d37ba0d7e73a2


### PR DESCRIPTION
Aims to prevent the following failure during boot:

```
error: ../../grub-core/loader/arm64/linux.c:61:plain image kernel not supported - rebuild with CONFIG(U)EFI_STUB enabled.
error: ../../grub-core/loader/arm64/linux.c:298:you need to load the kernel first.
```