### PR TITLE
Add rpi5 flavor with 16k page size

### DIFF
--- a/kernel.spec
+++ b/kernel.spec
@@ -51,6 +51,9 @@
 # Build a bcm2711 (RPi4) kernel
 %define with_rpi4       %{?_with_rpi4:       1} %{?!_with_rpi4: 0}
 
+# Build a bcm2712 (RPi5) kernel
+%define with_rpi5       %{?_with_rpi5:       1} %{?!_with_rpi5: 0}
+
 # For a stable, released kernel, released_kernel should be 1. For rawhide
 # and/or a kernel built from an rc or git snapshot, released_kernel should
 # be 0.
@@ -68,7 +71,7 @@
 # For non-released -rc kernels, this will be appended after the rcX and
 # gitX tags, so a 3 here would become part of release "0.rcX.gitX.3"
 #
-%global baserelease 1
+%global baserelease 2
 
 # RaspberryPi foundation git snapshot (short)
 %global rpi_gitshort 2f4a28199
@@ -100,6 +103,13 @@
 
 %if %{with_rpi4}
 %global variant -rpi4
+%global with_tools 0
+%global with_perf 0
+%global with_lpae 0
+%endif
+
+%if %{with_rpi5}
+%global variant -rpi5
 %global with_tools 0
 %global with_perf 0
 %global with_lpae 0
@@ -158,10 +168,14 @@
 
 %if %{with_bcm270x}
  %define bcm270x 1
- %if %{with_rpi4}
-  %define Flavour rpi4
+ %if %{with_rpi5}
+   %define Flavour rpi5
  %else
-  %define Flavour rpi
+  %if %{with_rpi4}
+   %define Flavour rpi4
+  %else
+   %define Flavour rpi
+  %endif
  %endif
  %define buildid .%{Flavour}
 %else
@@ -236,10 +250,14 @@ Summary: The Linux kernel for the Raspberry Pi (BCM283x)
 URL: http://www.kernel.org
 %else
 %if "%{_target_cpu}" != "armv6hl"
+%if %{with_rpi5}
+Summary: The BCM2712 Linux kernel port for the Raspberry Pi 5 Model B
+%else
 %if %{with_rpi4}
 Summary: The BCM2711 Linux kernel port for the Raspberry Pi 4 Model B
 %else
 Summary: The BCM2709 Linux kernel port for the Raspberry Pi 2 and 3 Model B
+%endif
 %endif
 %else
 Summary: The BCM2708 Linux kernel port for the Raspberry Pi Model A, B and Zero
@@ -647,10 +665,14 @@ Provides: installonlypkg(kernel)\
 # The main -core package
 %if %{bcm270x}
 %if "%{_target_cpu}" == "armv7hl"
+%if %{with_rpi5}
+%define variant_summary The Linux kernel for the Raspberry Pi 5 Model B
+%else
 %if %{with_rpi4}
 %define variant_summary The Linux kernel for the Raspberry Pi 4 Model B
 %else
 %define variant_summary The Linux kernel for the Raspberry Pi 2/3 Model B
+%endif
 %endif
 %else
 %define variant_summary The Linux kernel for the Raspberry Pi Model A, B & Zero
@@ -973,6 +995,9 @@ BuildKernel() {
     %endif
     %if %{bcm270x}
     %if "%{_target_cpu}" != "armv6hl"
+    %if %{with_rpi5}
+    make bcm2712_defconfig
+    %else
     %if %{with_rpi4}
     make bcm2711_defconfig
     %else
@@ -980,6 +1005,7 @@ BuildKernel() {
     make bcm2711_defconfig
     %else
     make bcm2709_defconfig
+    %endif
     %endif
     %endif
     %else
@@ -1449,6 +1475,9 @@ fi\
 /sbin/depmod -a %{KVERREL}%{?1:+%{1}}\
 mkdir -p /%{image_install_path}/efi/overlays\
 %if "%{_target_cpu}" != "armv6hl"\
+%if %{with_rpi5}\
+cp -f /lib/modules/%{KVERREL}%{?1:+%{1}}/%{install_name} /%{image_install_path}/efi/kernel_2712.img\
+%else\
 %if %{with_rpi4}\
 %ifarch aarch64\
 cp -f /lib/modules/%{KVERREL}%{?1:+%{1}}/%{install_name} /%{image_install_path}/efi/kernel8.img\
@@ -1457,6 +1486,7 @@ cp -f /lib/modules/%{KVERREL}%{?1:+%{1}}/%{install_name} /%{image_install_path}/
 %endif\
 %else\
 cp -f /lib/modules/%{KVERREL}%{?1:+%{1}}/%{install_name} /%{image_install_path}/efi/kernel7.img\
+%endif\
 %endif\
 %else\
 cp -f /lib/modules/%{KVERREL}%{?1:+%{1}}/%{install_name} /%{image_install_path}/efi/kernel.img\
@@ -1654,6 +1684,9 @@ fi
 
 
 %changelog
+* Sat Oct 11 2025 Ivan Mironov <mironov.ivan@gmail.com> - 6.12.49-2.rpi
+- Add rpi5 flavor with 16k page size
+
 * Fri Oct 03 2025 Damian Wrobel <dwrobel@ertelnet.rybnik.pl> - 6.12.49-1.rpi
 - Update to stable kernel patch v6.12.49
 - Sync RPi patch to git revision: 2f4a28199c418599ba0224186e42926b482b523c


### PR DESCRIPTION
Hi!

While existing rpi4 kernel works fine on Raspberry Pi 5, official Raspberry Pi images ship slightly different kernel for those SBCs. The main difference is the 16k page size. Here is the configuration diff:

```diff
--- config-6.12.49-1.rpi4.fc42.aarch64	2025-10-10 07:52:02.000000000 +0200
+++ config-6.12.49-2.rpi5.fc42.aarch64	2025-10-11 11:32:32.000000000 +0200
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.49-1.rpi4.fc42.aarch64 Kernel Configuration
+# Linux/arm64 6.12.49-2.rpi5.fc42.aarch64 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 15.2.1 20250808 (Red Hat 15.2.1-1)"
 CONFIG_CC_IS_GCC=y
@@ -289,11 +289,11 @@
 CONFIG_GCC_SUPPORTS_DYNAMIC_FTRACE_WITH_ARGS=y
 CONFIG_64BIT=y
 CONFIG_MMU=y
-CONFIG_ARM64_CONT_PTE_SHIFT=4
-CONFIG_ARM64_CONT_PMD_SHIFT=4
-CONFIG_ARCH_MMAP_RND_BITS_MIN=18
-CONFIG_ARCH_MMAP_RND_BITS_MAX=24
-CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MIN=11
+CONFIG_ARM64_CONT_PTE_SHIFT=7
+CONFIG_ARM64_CONT_PMD_SHIFT=5
+CONFIG_ARCH_MMAP_RND_BITS_MIN=16
+CONFIG_ARCH_MMAP_RND_BITS_MAX=30
+CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MIN=9
 CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX=16
 CONFIG_STACKTRACE_SUPPORT=y
 CONFIG_ILLEGAL_POINTER_VALUE=0xdead000000000000
@@ -420,13 +420,14 @@
 CONFIG_SOCIONEXT_SYNQUACER_PREITS=y
 # end of ARM errata workarounds via the alternatives framework
 
-CONFIG_ARM64_4K_PAGES=y
-# CONFIG_ARM64_16K_PAGES is not set
+# CONFIG_ARM64_4K_PAGES is not set
+CONFIG_ARM64_16K_PAGES=y
 # CONFIG_ARM64_64K_PAGES is not set
-CONFIG_ARM64_VA_BITS_39=y
+# CONFIG_ARM64_VA_BITS_36 is not set
+CONFIG_ARM64_VA_BITS_47=y
 # CONFIG_ARM64_VA_BITS_48 is not set
 # CONFIG_ARM64_VA_BITS_52 is not set
-CONFIG_ARM64_VA_BITS=39
+CONFIG_ARM64_VA_BITS=47
 CONFIG_ARM64_PA_BITS_48=y
 CONFIG_ARM64_PA_BITS=48
 # CONFIG_CPU_BIG_ENDIAN is not set
@@ -457,7 +458,7 @@
 CONFIG_ARCH_SUPPORTS_CRASH_DUMP=y
 CONFIG_ARCH_DEFAULT_CRASH_DUMP=y
 # CONFIG_XEN is not set
-CONFIG_ARCH_FORCE_MAX_ORDER=10
+CONFIG_ARCH_FORCE_MAX_ORDER=11
 CONFIG_UNMAP_KERNEL_AT_EL0=y
 CONFIG_MITIGATE_SPECTRE_BRANCH_HISTORY=y
 CONFIG_RODATA_FULL_DEFAULT_ENABLED=y
@@ -741,11 +742,11 @@
 CONFIG_ARCH_MMAP_RND_BITS=18
 CONFIG_HAVE_ARCH_MMAP_RND_COMPAT_BITS=y
 CONFIG_ARCH_MMAP_RND_COMPAT_BITS=11
-CONFIG_HAVE_PAGE_SIZE_4KB=y
-CONFIG_PAGE_SIZE_4KB=y
+CONFIG_HAVE_PAGE_SIZE_16KB=y
+CONFIG_PAGE_SIZE_16KB=y
 CONFIG_PAGE_SIZE_LESS_THAN_64KB=y
 CONFIG_PAGE_SIZE_LESS_THAN_256KB=y
-CONFIG_PAGE_SHIFT=12
+CONFIG_PAGE_SHIFT=14
 CONFIG_ARCH_WANT_DEFAULT_TOPDOWN_MMAP_LAYOUT=y
 CONFIG_CLONE_BACKWARDS=y
 CONFIG_OLD_SIGSUSPEND3=y
@@ -965,7 +966,6 @@
 CONFIG_DEFAULT_MMAP_MIN_ADDR=4096
 CONFIG_ARCH_SUPPORTS_MEMORY_FAILURE=y
 # CONFIG_MEMORY_FAILURE is not set
-CONFIG_ARCH_WANTS_THP_SWAP=y
 # CONFIG_TRANSPARENT_HUGEPAGE is not set
 CONFIG_NEED_PER_CPU_EMBED_FIRST_CHUNK=y
 CONFIG_NEED_PER_CPU_PAGE_FIRST_CHUNK=y
@@ -3722,7 +3722,7 @@
 # CONFIG_SERIAL_FSL_LINFLEXUART is not set
 # CONFIG_SERIAL_CONEXANT_DIGICOLOR is not set
 # CONFIG_SERIAL_SPRD is not set
-CONFIG_SERIAL_RPI_FW=m
+# CONFIG_SERIAL_RPI_FW is not set
 # end of Serial drivers
 
 CONFIG_SERIAL_MCTRL_GPIO=y
@@ -5687,7 +5687,6 @@
 # CONFIG_DRM_RADEON is not set
 # CONFIG_DRM_AMDGPU is not set
 # CONFIG_DRM_NOUVEAU is not set
-# CONFIG_DRM_XE is not set
 # CONFIG_DRM_VGEM is not set
 # CONFIG_DRM_VKMS is not set
 # CONFIG_DRM_VMWGFX is not set
```

This patch simply adds a new kernel flavor for Raspberry Pi 5.

I successfully tested this on Raspberry Pi 500+ with Fedora Workstation image:

```text
before:
    im@fedora:~$ uname -a
    Linux fedora 6.12.49-1.rpi4.fc42.aarch64 #1 SMP PREEMPT Fri Oct  3 20:22:10 UTC 2025 aarch64 GNU/Linux
    im@fedora:~$ getconf PAGESIZE
    4096

after:
    im@fedora:~$ uname -a
    Linux fedora 6.12.49-2.rpi5.fc42.aarch64 #1 SMP PREEMPT Sat Oct 11 11:25:14 CEST 2025 aarch64 GNU/Linux
    im@fedora:~$ getconf PAGESIZE
    16384
```